### PR TITLE
Release/5.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Attached wp-config.php in this container is designed to use with configuration p
 
 nginx configuration has a lot of tweaks, and this container run a cron via system instead of WP cron because is not very reliable.
 
-Currently image size is 152 MB, but the goal of this project is to slim it as possible.
+Currently image size is 215 MB, but the goal of this project is to slim it as possible.
 
 ## Installing
 

--- a/rootfs/robots.txt
+++ b/rootfs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /wp-admin/
+Allow: /wp-admin/admin-ajax.php


### PR DESCRIPTION
This release not only uses latest official *WordPress release* `5.3.2`, also have several changes:

- Docker multilayer build
- Updated to latest version (5.3.2)
- Added symlink for php-fpm
- Updated README.md with new size (unfortunately has grown, i will work to reduce in the future)
- Added robots.txt in `rootfs` folder
- Added sed in passwd file
- Added empty includes.conf file inside under nginx_includes to avoid errors in Docker build image