### PR TITLE
Correct codeable.io Reference Part 1 Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please note: Attached docker-compose is focused on production environment, so yo
 ## References
 
 * https://github.com/docker-library/wordpress
-* https://codeable.io/wordpress-developers-intro-to-docker-part-one/
+* https://codeable.io/blog/wordpress-developers-intro-docker/
 * https://codeable.io/wordpress-developers-intro-to-docker-part-two/
 * https://github.com/TrafeX/docker-php-nginx/
 * https://hub.docker.com/_/wordpress/


### PR DESCRIPTION
Looks like Codeable.io updated the URL for their Part 1 Wordpress Article

I've updated it: 

https://codeable.io/wordpress-developers-intro-to-docker-part-one/ --> https://codeable.io/blog/wordpress-developers-intro-docker/