### PR TITLE
Add missing PHP modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN adduser -u $UID -D -S -G www-data www-data \
        php82-xmlreader \
        php82-zip \
        php82-opcache \
+       php82-fileinfo \
+       php82-iconv \
        less
 
 RUN { \


### PR DESCRIPTION
Added `iconv` and `fileinfo` PHP modules [as official documentation](https://make.wordpress.org/hosting/handbook/server-environment/#php-extensions) recommends.