### PR TITLE
Release WordPress 7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM public.ecr.aws/docker/library/alpine:3.23
 LABEL Maintainer="Carlos R <nidr0x@gmail.com>" \
   Description="Slim WordPress image using Alpine Linux"
 
-ENV WP_VERSION=6.9.4
+ENV WP_VERSION=7.0
 ENV WP_LOCALE=en_US
 
 ARG UID=82

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Production-oriented WordPress container stack based on Alpine Linux.
 
 ## Stack
 
-- WordPress 6.x (downloaded by `wp-cli`)
+- WordPress 7.0 (downloaded by `wp-cli`)
 - PHP-FPM 8.5 (ondemand process manager)
 - Nginx
 - Supervisor + cron


### PR DESCRIPTION
- Bump the Docker image WordPress version from 6.9.4 to 7.0.
- Update the README stack summary to reflect WordPress 7.0.