### PR TITLE
Widen release tag matching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
     - cron: "0 0 * * *"
   push:
     tags:
+      - "*.*"
       - "*.*.*"
 
 permissions:


### PR DESCRIPTION
Trigger the release workflow for two-part version tags like 7.0.