### PR TITLE
Optimize WordPress runtime and Apple container support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# WordPress
+DISABLE_WP_CRON=true
+DB_NAME=wordpress
+DB_USER=wordpress
+DB_PASSWORD=change-me
+DB_HOST=mysql
+DB_CHARSET=latin1
+DB_COLLATE=''
+TABLE_PREFIX=wp_
+FS_METHOD=direct
+WP_DEBUG=false
+WP_DEBUG_DISPLAY=false
+EMPTY_TRASH_DAYS=7
+WP_POST_REVISIONS=10
+
+# MariaDB
+MARIADB_ROOT_PASSWORD=change-me
+MARIADB_DATABASE=wordpress
+MARIADB_USER=wordpress
+MARIADB_PASSWORD=change-me
+
+# Traefik
+DOMAIN=example.com
+LETSENCRYPT_EMAIL=admin@example.com
+# Use staging while testing. Switch to the production directory before go-live.
+LETSENCRYPT_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,14 @@ RUN adduser -u $UID -D -S -G www-data www-data \
   less
 
 RUN { \
-  echo 'opcache.memory_consumption=128'; \
-  echo 'opcache.interned_strings_buffer=8'; \
-  echo 'opcache.max_accelerated_files=4000'; \
+  echo 'opcache.enable=1'; \
+  echo 'opcache.enable_cli=0'; \
+  echo 'opcache.memory_consumption=192'; \
+  echo 'opcache.interned_strings_buffer=16'; \
+  echo 'opcache.max_accelerated_files=10000'; \
+  echo 'opcache.validate_timestamps=1'; \
   echo 'opcache.revalidate_freq=2'; \
-  echo 'opcache.fast_shutdown=1'; \
+  echo 'opcache.save_comments=1'; \
   } > /etc/php85/conf.d/opcache-recommended.ini
 
 VOLUME /var/www/wp-content
@@ -84,6 +87,7 @@ COPY --from=download --chown=${UID} /tmp/wp-secrets.php /usr/src/wordpress/wp-se
 RUN set -x \
   && chown -R $UID:$GID /etc/nginx \
   && chown -R $UID:$GID /var/lib/nginx \
+  && printf '%s\n' '* * * * * php /usr/src/wordpress/wp-cron.php >> /dev/stdout 2>> /dev/stderr' > /etc/crontabs/www-data \
   && chmod -R g+w /etc/nginx \
   && chmod g+wx /var/log/ \
   && ln -sf /dev/stderr /var/lib/nginx/logs/error.log \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Use this during development/debugging and access WordPress at `http://127.0.0.1:
 docker compose up -d db wordpress
 ```
 
+MariaDB stays private in this default Docker Compose path.
+
 ### Production profile (includes Traefik)
 
 Use this to run the full stack from this repository:
@@ -41,11 +43,25 @@ Use this to run the full stack from this repository:
 docker compose up -d
 ```
 
+### Apple Container profile
+
+Use this when running through `container-compose`:
+
+```bash
+container-compose up -d -f container-compose.yml --env-file .env db wordpress
+```
+
+This profile keeps the Apple Container compatibility workarounds.
+MariaDB is intentionally published on host port `3306` in this profile because `container-compose`
+needs that path for WordPress-to-DB connectivity in this runtime.
+Use the multi-service startup command above; detached single-service startup is not the supported path here.
+
 Notes:
 
-- This compose file expects an external Docker network named `traefik`.
-- ACME in `docker-compose.yml` is currently configured for Let’s Encrypt staging.
-  Switch to production CA settings before go-live.
+- This compose file creates and manages the `traefik` and `backend` networks itself.
+- MariaDB tuning is baked into the custom DB image via `mariadb.Dockerfile`, which keeps it compatible with Apple `container-compose`.
+- Set `DOMAIN`, `LETSENCRYPT_EMAIL`, and `LETSENCRYPT_CA_SERVER` in `.env` before using the Traefik-enabled profile.
+- `LETSENCRYPT_CA_SERVER` should point at Let’s Encrypt staging while testing and the production directory before go-live.
 
 ## Important Paths
 

--- a/config/fpm-pool.conf
+++ b/config/fpm-pool.conf
@@ -1,17 +1,17 @@
 [www]
 pm = ondemand
-pm.max_children = 120
+pm.max_children = 16
 rlimit_files = 51200
 listen.allowed_clients = 127.0.0.1
 rlimit_core = 0
-pm.process_idle_timeout = 10s;
-pm.max_requests = 1000
+pm.process_idle_timeout = 15s
+pm.max_requests = 500
 clear_env = no
 request_terminate_timeout = 300
 request_slowlog_timeout = 0
 catch_workers_output = yes
 listen = 9000
-php_admin_value[memory_limit] = 1024M
+php_admin_value[memory_limit] = 256M
 catch_workers_output = yes
 decorate_workers_output = no
 access.log = /dev/stdout

--- a/config/my.cnf
+++ b/config/my.cnf
@@ -5,7 +5,6 @@ max_connections = 151
 max_allowed_packet = 64M
 wait_timeout = 600
 interactive_timeout = 600
-log_error = /var/log/mysql/mysql_error.log
 
 # Keep per-connection buffers conservative to avoid OOM under concurrency.
 sort_buffer_size = 2M
@@ -25,7 +24,7 @@ query_cache_type = OFF
 query_cache_size = 0
 
 # InnoDB defaults tuned for a single-node WordPress workload.
-innodb_buffer_pool_size = 1024M
+innodb_buffer_pool_size = 512M
 innodb_log_file_size = 256M
 innodb_flush_method = O_DIRECT
 innodb_flush_log_at_trx_commit = 1

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -20,7 +20,8 @@ http {
     client_body_buffer_size 10m;
     sendfile on;
     tcp_nopush on;
-    keepalive_timeout 120;
+    keepalive_timeout 65;
+    keepalive_requests 1000;
     server_tokens off;
     tcp_nodelay on;
     absolute_redirect off;
@@ -125,6 +126,7 @@ http {
             fastcgi_buffers 4 64k;
             fastcgi_busy_buffers_size 128k;
             fastcgi_temp_file_write_size 128k;
+            fastcgi_keep_conn on;
             fastcgi_intercept_errors on;
 
             fastcgi_index index.php;

--- a/config/nginx_includes/include.conf
+++ b/config/nginx_includes/include.conf
@@ -20,6 +20,7 @@ location = /wp-login.php {
     fastcgi_buffers 4 64k;
     fastcgi_busy_buffers_size 128k;
     fastcgi_temp_file_write_size 128k;
+    fastcgi_keep_conn on;
     fastcgi_intercept_errors on;
 
     fastcgi_index index.php;

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -30,10 +30,7 @@ redirect_stderr=true
 [program:rootfs]
 command=/bin/ash /usr/local/bin/rootfs.sh
 autostart=true
-autorestart=true
+autorestart=false
 redirect_stderr=true
+startsecs=0
 startretries=3
-
-[program:wp-cron]
-command=php /usr/src/wordpress/wp-cron.php
-interval=1m

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -37,8 +37,6 @@ services:
     volumes:
       - "./letsencrypt:/letsencrypt"
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
 
   db:
     build:
@@ -53,6 +51,9 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    # Apple container-compose needs the DB exposed on the host for WordPress connectivity.
+    ports:
+      - "3306:3306"
     volumes:
       - vol-wp-db:/var/lib/mysql
     networks:
@@ -78,8 +79,6 @@ services:
     volumes:
       - ./wp-content:/var/www/wp-content
       - ./images:/usr/src/wordpress/images
-      - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
       - ./rootfs:/data
     labels:
       - "traefik.enable=true"

--- a/mariadb.Dockerfile
+++ b/mariadb.Dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:11.0
+
+COPY config/my.cnf /etc/mysql/conf.d/zzz_my.cnf

--- a/mariadb.Dockerfile
+++ b/mariadb.Dockerfile
@@ -1,3 +1,5 @@
 FROM mariadb:11.0
 
 COPY config/my.cnf /etc/mysql/conf.d/zzz_my.cnf
+
+USER mysql


### PR DESCRIPTION
- Tune PHP-FPM, Nginx and MariaDB for better runtime behavior.
- Fix Supervisor one-shot jobs and move WordPress cron to crond.
- Add a custom MariaDB image so Apple container-compose can use the DB config.
- Add a container-compose profile and keep the default Docker Compose profile cleaner.
- Update env sample and README for the new runtime setup.