### PR TITLE
Tighten Dockerfile log permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN adduser -u $UID -D -S -G www-data www-data \
   php85-mbstring \
   php85-gd \
   php85-exif \
-  nginx \
+  nginx=1.28.3-r2 \
   supervisor \
   php85-zlib \
   php85-xml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ RUN set -x \
   && chown -R $UID:$GID /etc/nginx \
   && chown -R $UID:$GID /var/lib/nginx \
   && chmod -R g+w /etc/nginx \
-  && chmod g+wx /var/log/ \
   && ln -sf /dev/stderr /var/lib/nginx/logs/error.log \
   && deluser nginx \
   && rm -rf /tmp/* \


### PR DESCRIPTION
This removes the broad group write permission on /var/log from the WordPress image. Nginx and PHP-FPM already log to stdout/stderr in this image.