### PR TITLE
perf: tune php-fpm pool behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,11 @@ RUN { \
   echo 'opcache.enable_cli=0'; \
   echo 'opcache.memory_consumption=192'; \
   echo 'opcache.interned_strings_buffer=16'; \
-  echo 'opcache.max_accelerated_files=10000'; \
-  echo 'opcache.validate_timestamps=1'; \
-  echo 'opcache.revalidate_freq=2'; \
+  echo 'opcache.max_accelerated_files=20000'; \
+  echo 'opcache.validate_timestamps=0'; \
+  echo 'opcache.revalidate_freq=0'; \
   echo 'opcache.save_comments=1'; \
+  echo 'opcache.fast_shutdown=1'; \
   } > /etc/php85/conf.d/opcache-recommended.ini
 
 VOLUME /var/www/wp-content

--- a/config/fpm-pool.conf
+++ b/config/fpm-pool.conf
@@ -1,14 +1,17 @@
 [www]
-pm = ondemand
+pm = dynamic
 pm.max_children = 16
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 4
 rlimit_files = 51200
 listen.allowed_clients = 127.0.0.1
 rlimit_core = 0
-pm.process_idle_timeout = 15s
-pm.max_requests = 500
+pm.max_requests = 400
 clear_env = no
 request_terminate_timeout = 300
-request_slowlog_timeout = 0
+request_slowlog_timeout = 5s
+slowlog = /tmp/php-fpm.slow.log
 catch_workers_output = yes
 listen = 9000
 php_admin_value[memory_limit] = 256M

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -6,7 +6,7 @@ error_log /dev/stderr notice;
 
 events {
     use epoll;
-    worker_connections  1024;
+    worker_connections  4096;
     multi_accept on;
 }
 
@@ -112,6 +112,12 @@ http {
             add_header Cache-Control "public";
         }
 
+        location ~* ^/wp-content/.*\.(?:css|js|jpg|jpeg|gif|png|svg|webp|avif|ico|woff|woff2|ttf|otf)$ {
+            root /var/www;
+            expires 30d;
+            add_header Cache-Control "public, max-age=2592000, immutable";
+        }
+
         location / {
             try_files $uri $uri/ /index.php?$args;
         }
@@ -119,9 +125,9 @@ http {
         location ~ [^/]\.php(/|$) {
             try_files $uri =404;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_connect_timeout 300;
-            fastcgi_send_timeout 300;
-            fastcgi_read_timeout 300;
+            fastcgi_connect_timeout 10;
+            fastcgi_send_timeout 60;
+            fastcgi_read_timeout 60;
             fastcgi_buffer_size 64k;
             fastcgi_buffers 4 64k;
             fastcgi_busy_buffers_size 128k;

--- a/config/nginx_includes/include.conf
+++ b/config/nginx_includes/include.conf
@@ -13,9 +13,9 @@ location = /wp-login.php {
     limit_req zone=wp_login burst=20 nodelay;
     try_files $uri =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_connect_timeout 300;
-    fastcgi_send_timeout 300;
-    fastcgi_read_timeout 300;
+    fastcgi_connect_timeout 10;
+    fastcgi_send_timeout 60;
+    fastcgi_read_timeout 60;
     fastcgi_buffer_size 64k;
     fastcgi_buffers 4 64k;
     fastcgi_busy_buffers_size 128k;
@@ -27,4 +27,26 @@ location = /wp-login.php {
     fastcgi_pass 127.0.0.1:9000;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     include fastcgi_params;
+}
+
+location = /ping {
+    allow 127.0.0.1;
+    allow ::1;
+    deny all;
+
+    fastcgi_pass 127.0.0.1:9000;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param SCRIPT_NAME /ping;
+}
+
+location = /status {
+    allow 127.0.0.1;
+    allow ::1;
+    deny all;
+
+    fastcgi_pass 127.0.0.1:9000;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param SCRIPT_NAME /status;
 }


### PR DESCRIPTION
- Tune PHP-FPM pool for steadier request handling
- Reduce nginx FastCGI timeouts and improve static asset caching
- Add local-only `/ping` and `/status` endpoints for PHP-FPM health checks
- Improve OPcache defaults for production builds