### PR TITLE
build: optimize docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.DS_Store
+.env
+.env.*
+
+wp-content
+images
+letsencrypt
+scripts
+rootfs
+
+*.log
+*.tmp
+*.swp
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ FROM public.ecr.aws/docker/library/alpine:3.23
 LABEL Maintainer="Carlos R <nidr0x@gmail.com>" \
   Description="Slim WordPress image using Alpine Linux"
 
-ENV WP_VERSION=7.0
-ENV WP_LOCALE=en_US
-
 ARG UID=82
 ARG GID=82
 
@@ -47,8 +44,7 @@ RUN adduser -u $UID -D -S -G www-data www-data \
   php85-xmlreader \
   php85-zip \
   php85-fileinfo \
-  php85-iconv \
-  less
+  php85-iconv
 
 RUN { \
   echo 'opcache.memory_consumption=128'; \
@@ -94,6 +90,9 @@ RUN set -x \
   && rm -rf /var/www/localhost
 
 USER ${UID}
+
+ARG WP_VERSION=7.0
+ARG WP_LOCALE=en_US
 
 RUN set -x \
   && wp core download --path=/usr/src/wordpress --version="${WP_VERSION}" --skip-content --locale="${WP_LOCALE}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN adduser -u $UID -D -S -G www-data www-data \
   php85-mbstring \
   php85-gd \
   php85-exif \
-  nginx=1.28.3-r2 \
+  nginx \
   supervisor \
   php85-zlib \
   php85-xml \

--- a/scripts/read-wp-version.sh
+++ b/scripts/read-wp-version.sh
@@ -4,12 +4,12 @@ set -eu
 
 dockerfile="${1:-Dockerfile}"
 
-matches="$(grep -En '^ENV[[:space:]]+WP_VERSION=[^[:space:]]+$' "$dockerfile" || true)"
+matches="$(grep -En '^(ENV|ARG)[[:space:]]+WP_VERSION=[^[:space:]]+$' "$dockerfile" || true)"
 count="$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d ' ')"
 
 if [ "$count" -ne 1 ]; then
-  echo "Expected exactly one ENV WP_VERSION=... line in $dockerfile, found $count." >&2
+  echo "Expected exactly one ARG or ENV WP_VERSION=... line in $dockerfile, found $count." >&2
   exit 1
 fi
 
-printf '%s\n' "$matches" | sed -E 's/^[0-9]+:ENV[[:space:]]+WP_VERSION=([^[:space:]]+)$/\1/'
+printf '%s\n' "$matches" | sed -E 's/^[0-9]+:(ENV|ARG)[[:space:]]+WP_VERSION=([^[:space:]]+)$/\2/'


### PR DESCRIPTION
- Added .dockerignore to send less files during Docker build.
- Moved WP_VERSION and WP_LOCALE near the WordPress download step to keep Docker cache working better.
- Removed less from the image.
- Updated the version script so CI still works with ARG instead of ENV.
- Use latest nginx package version again.